### PR TITLE
zephyr: Add zephyr board aliases

### DIFF
--- a/examples/system.yaml
+++ b/examples/system.yaml
@@ -26,6 +26,13 @@ common:
   # zephyr applications.
   zephyr-template: applications/${application}
 
+# For Zephyr boards whose board string contains a forward slash, it is
+# necessary to define a slash-free alias.
+# For other Zephyr boards, this is optional.
+zephyr-aliases:
+  stm32h747i_disco_m7: stm32h747i_disco/stm32h747xx/m7
+  stm32h747i_disco_m4: stm32h747i_disco/stm32h747xx/m4
+
 zephyr:
   - application: foobar
     # This is the same as if we left it out because of zephyr-template.

--- a/makemehappy/build.py
+++ b/makemehappy/build.py
@@ -84,6 +84,19 @@ def generateInstances(log, mod):
 
     return instances
 
+class InvalidZephyrAlias(Exception):
+    pass
+
+def generateZephyrAliases(data):
+    aliases = {}
+    alias_forbidden_chars = ['/', ' ']
+    aliases_yaml = data['zephyr-aliases']
+    for alias in aliases_yaml.keys():
+        if any(char in alias for char in alias_forbidden_chars):
+            raise InvalidZephyrAlias(alias)
+        aliases[alias] = aliases_yaml[alias]
+
+
 def generateZephyrInstances(log, mod):
     targets = mod.targets()
     cfgs = mod.buildconfigs()
@@ -98,11 +111,14 @@ def generateZephyrInstances(log, mod):
     if ('install' in mod.moduleData):
         install = mod.moduleData['install']
 
+    aliases = generateZephyrAliases(mod.moduleData)
+
     instances = []
     for target in targets:
         for cfg in cfgs:
             for tool in tools:
                 for board in target['boards']:
+                    zephyr_board = aliases.get(board, board)
                     for tc in target['toolchains']:
                         if ('kconfig' not in target):
                             target['kconfig'] = []
@@ -121,6 +137,7 @@ def generateZephyrInstances(log, mod):
                         instances.append(
                             { 'toolchain'   : tc,
                               'board'       : board,
+                              'zephyr_board': zephyr_board,
                               'architecture': board,
                               'name'        : name,
                               'application' : target['application'],
@@ -201,7 +218,7 @@ def cmakeConfigure(cfg, log, args, stats, ext, root, instance):
             log         = log,
             args        = cmakeArgs,
             ufw         = os.path.join(root, 'deps', 'ufw'),
-            board       = instance['board'],
+            zephyr_board= instance['zephyr_board'],
             buildconfig = instance['buildcfg'],
             toolchain   = instance['toolchain'],
             sourcedir   = root,

--- a/makemehappy/build.py
+++ b/makemehappy/build.py
@@ -84,18 +84,6 @@ def generateInstances(log, mod):
 
     return instances
 
-class InvalidZephyrAlias(Exception):
-    pass
-
-def generateZephyrAliases(data):
-    aliases = {}
-    alias_forbidden_chars = ['/', ' ']
-    aliases_yaml = data['zephyr-aliases']
-    for alias in aliases_yaml.keys():
-        if any(char in alias for char in alias_forbidden_chars):
-            raise InvalidZephyrAlias(alias)
-        aliases[alias] = aliases_yaml[alias]
-
 
 def generateZephyrInstances(log, mod):
     targets = mod.targets()
@@ -111,7 +99,7 @@ def generateZephyrInstances(log, mod):
     if ('install' in mod.moduleData):
         install = mod.moduleData['install']
 
-    aliases = generateZephyrAliases(mod.moduleData)
+    aliases = z.generateZephyrAliases(mod.moduleData)
 
     instances = []
     for target in targets:

--- a/makemehappy/cmake.py
+++ b/makemehappy/cmake.py
@@ -87,7 +87,7 @@ class InvalidZephyrModuleSpec(Exception):
     pass
 
 def configureZephyr(log, args, ufw,
-                    board, buildtool, buildconfig, buildsystem,
+                    zephyr_board, buildtool, buildconfig, buildsystem,
                     toolchain, sourcedir, builddir, installdir,
                     appsource, kernel, dtc, kconfig,
                     modulepath, modules):
@@ -113,7 +113,7 @@ def configureZephyr(log, args, ufw,
           zephyrToolchain(toolchain),
           makeParam('CMAKE_BUILD_TYPE',       buildconfig),
           makeParam('CMAKE_INSTALL_PREFIX',   installdir),
-          makeParam('BOARD',                  board),
+          makeParam('BOARD',                  zephyr_board),
           makeParam('ZEPHYR_MODULES',         modules),
           makeParam('DTC_OVERLAY_FILE',       dtc),
           makeParam('OVERLAY_CONFIG',         overlay),

--- a/makemehappy/system.py
+++ b/makemehappy/system.py
@@ -231,7 +231,7 @@ class SystemInstanceZephyr:
             log         = self.sys.log,
             args        = cargs,
             ufw         = build['ufw'],
-            board       = self.board,
+            zephyr_board= self.board,
             buildconfig = self.cfg,
             toolchain   = z.findToolchain(build, self.tc),
             sourcedir   = '.',

--- a/makemehappy/system.py
+++ b/makemehappy/system.py
@@ -36,20 +36,6 @@ def makeZephyrInstances(zephyr):
                         board, name, tcname, cfg)])
     return instances
 
-class InvalidZephyrAlias(Exception):
-    pass
-
-def makeZephyrAliases(data):
-    aliases = {}
-    alias_forbidden_chars = ['/', ' ']
-    aliases_yaml = data['zephyr-aliases']
-    for alias in aliases_yaml.keys():
-        if any(char in alias for char in alias_forbidden_chars):
-            raise InvalidZephyrAlias(alias)
-        aliases[alias] = aliases_yaml[alias]
-
-    return aliases
-
 def makeBoardInstances(board):
     instances = []
     for cfg in board['build-configs']:
@@ -185,8 +171,8 @@ class SystemInstanceBoard:
 class SystemInstanceZephyr:
     def __init__(self, sys, board, app, tc, cfg):
         self.sys = sys
-        self.board_alias = board
-        self.board = self.sys.matchZephyrAlias(board)
+        self.board = board
+        self.zephyr_board = self.sys.matchZephyrAlias(board)
         self.app = app
         self.tc = tc
         self.cfg = cfg
@@ -204,16 +190,16 @@ class SystemInstanceZephyr:
                                            self.spec['install-dir'])
         else:
             self.builddir = os.path.join(self.sys.args.directory, 'zephyr',
-                                         self.board_alias, self.app, self.tc, self.cfg)
+                                         self.board, self.app, self.tc, self.cfg)
             self.installdir = os.path.join(self.systemdir,
                                            self.sys.args.directory,
                                            self.spec['install-dir'],
-                                           self.board_alias, self.tc, self.app, self.cfg)
-        self.sys.stats.systemZephyr(app, tc, self.board, cfg, self.spec['build-tool'])
+                                           self.board, self.tc, self.app, self.cfg)
+        self.sys.stats.systemZephyr(app, tc, self.zephyr_board, cfg, self.spec['build-tool'])
 
     def configure(self):
         build = z.findBuild(self.spec['build'], self.tc,
-                            self.board_alias)
+                            self.board)
 
         tmp = copy.deepcopy(self.spec)
         tmp.pop('build', None)
@@ -231,7 +217,7 @@ class SystemInstanceZephyr:
             log         = self.sys.log,
             args        = cargs,
             ufw         = build['ufw'],
-            zephyr_board= self.board,
+            zephyr_board= self.zephyr_board,
             buildconfig = self.cfg,
             toolchain   = z.findToolchain(build, self.tc),
             sourcedir   = '.',
@@ -452,7 +438,7 @@ class System:
         self.data = mmh.load(self.spec)
         fillData(self.data)
         self.instances = makeInstances(self.data)
-        self.zephyr_aliases = makeZephyrAliases(self.data)
+        self.zephyr_aliases = z.generateZephyrAliases(self.data)
         self.args.instances = mmh.patternsToList(self.instances,
                                                  self.args.instances)
         if (len(self.args.instances) > 0):

--- a/makemehappy/system.py
+++ b/makemehappy/system.py
@@ -36,6 +36,25 @@ def makeZephyrInstances(zephyr):
                         board, name, tcname, cfg)])
     return instances
 
+def makeZephyrAliases(data):
+    aliases = {}
+    for alias in data['zephyr-aliases']:
+        alias_name = alias['alias']
+        if 'board-string' in alias:
+            aliases[alias_name] = alias['board-string']
+        if 'board-name' in alias:
+            board_string = alias['board-name']
+            if 'revision' in alias:
+                board_string += '@' + alias['revision']
+            if 'soc' in alias:
+                board_string += '/' + alias['soc']
+                if 'cpu-cluster' in alias:
+                    board_string += '/' + alias['cpu-cluster']
+                if 'variant' in alias:
+                    board_string += '/' + alias['variant']
+            aliases[alias_name] = board_string
+    return aliases
+
 def makeBoardInstances(board):
     instances = []
     for cfg in board['build-configs']:
@@ -171,7 +190,8 @@ class SystemInstanceBoard:
 class SystemInstanceZephyr:
     def __init__(self, sys, board, app, tc, cfg):
         self.sys = sys
-        self.board = board
+        self.board_alias = board
+        self.board = self.sys.matchZephyrAlias(board)
         self.app = app
         self.tc = tc
         self.cfg = cfg
@@ -189,15 +209,16 @@ class SystemInstanceZephyr:
                                            self.spec['install-dir'])
         else:
             self.builddir = os.path.join(self.sys.args.directory, 'zephyr',
-                                         self.board, self.app, self.tc, self.cfg)
+                                         self.board_alias, self.app, self.tc, self.cfg)
             self.installdir = os.path.join(self.systemdir,
                                            self.sys.args.directory,
                                            self.spec['install-dir'],
-                                           self.board, self.tc, self.app, self.cfg)
-        self.sys.stats.systemZephyr(app, tc, board, cfg, self.spec['build-tool'])
+                                           self.board_alias, self.tc, self.app, self.cfg)
+        self.sys.stats.systemZephyr(app, tc, self.board, cfg, self.spec['build-tool'])
 
     def configure(self):
-        build = z.findBuild(self.spec['build'], self.tc, self.board)
+        build = z.findBuild(self.spec['build'], self.tc,
+                            self.board_alias)
 
         tmp = copy.deepcopy(self.spec)
         tmp.pop('build', None)
@@ -436,6 +457,7 @@ class System:
         self.data = mmh.load(self.spec)
         fillData(self.data)
         self.instances = makeInstances(self.data)
+        self.zephyr_aliases = makeZephyrAliases(self.data)
         self.args.instances = mmh.patternsToList(self.instances,
                                                  self.args.instances)
         if (len(self.args.instances) > 0):
@@ -461,6 +483,9 @@ class System:
                           .format(self.stats.countFailed(),
                                   self.stats.countBuilds()))
             raise(SystemFailedSomeBuilds())
+
+    def matchZephyrAlias(self, name):
+        return self.zephyr_aliases.get(name, name)
 
     def buildInstances(self, instances):
         for i in instances:

--- a/makemehappy/system.py
+++ b/makemehappy/system.py
@@ -36,23 +36,18 @@ def makeZephyrInstances(zephyr):
                         board, name, tcname, cfg)])
     return instances
 
+class InvalidZephyrAlias(Exception):
+    pass
+
 def makeZephyrAliases(data):
     aliases = {}
-    for alias in data['zephyr-aliases']:
-        alias_name = alias['alias']
-        if 'board-string' in alias:
-            aliases[alias_name] = alias['board-string']
-        if 'board-name' in alias:
-            board_string = alias['board-name']
-            if 'revision' in alias:
-                board_string += '@' + alias['revision']
-            if 'soc' in alias:
-                board_string += '/' + alias['soc']
-                if 'cpu-cluster' in alias:
-                    board_string += '/' + alias['cpu-cluster']
-                if 'variant' in alias:
-                    board_string += '/' + alias['variant']
-            aliases[alias_name] = board_string
+    alias_forbidden_chars = ['/', ' ']
+    aliases_yaml = data['zephyr-aliases']
+    for alias in aliases_yaml.keys():
+        if any(char in alias for char in alias_forbidden_chars):
+            raise InvalidZephyrAlias(alias)
+        aliases[alias] = aliases_yaml[alias]
+
     return aliases
 
 def makeBoardInstances(board):

--- a/makemehappy/zephyr.py
+++ b/makemehappy/zephyr.py
@@ -98,7 +98,7 @@ def westRevision(src, west, mod):
 def generateZephyrAliases(data):
     aliases = {}
     alias_forbidden_chars = ['/', ' ']
-    aliases_yaml = data['zephyr-aliases']
+    aliases_yaml = data.get('zephyr-aliases', {})
     for alias in aliases_yaml.keys():
         if any(char in alias for char in alias_forbidden_chars):
             raise InvalidZephyrAlias(alias)

--- a/makemehappy/zephyr.py
+++ b/makemehappy/zephyr.py
@@ -2,6 +2,9 @@ import os
 
 import makemehappy.utilities as mmh
 
+class InvalidZephyrAlias(Exception):
+    pass
+
 def isModule(d):
     return (os.path.isdir(d) and
             os.path.isdir(os.path.join(d, 'zephyr')))
@@ -91,3 +94,13 @@ def westRevision(src, west, mod):
     if ('revision' not in zmod):
         return None
     return zmod['revision']
+
+def generateZephyrAliases(data):
+    aliases = {}
+    alias_forbidden_chars = ['/', ' ']
+    aliases_yaml = data['zephyr-aliases']
+    for alias in aliases_yaml.keys():
+        if any(char in alias for char in alias_forbidden_chars):
+            raise InvalidZephyrAlias(alias)
+        aliases[alias] = aliases_yaml[alias]
+    return aliases


### PR DESCRIPTION
Zephyr 3.7 introduces a new hardware model, where boards can now contain optional board qualifiers. Parts of this board description are now separated by slashes. This conflicts with the makemehappy target strings.

To solve this, add the possibility to assign aliases to Zephyr board targets which do not contain slashes. Any Zephyr board target can now be uniquely identified by an alias assigned to it by