### PR TITLE
system: zephyr: Add key for specifying additional config files

### DIFF
--- a/makemehappy/build.py
+++ b/makemehappy/build.py
@@ -213,6 +213,7 @@ def cmakeConfigure(cfg, log, args, stats, ext, root, instance):
             kernel      = os.path.join(root, 'deps', 'zephyr-kernel'),
             dtc         = instance['dtc-overlays'],
             kconfig     = instance['kconfig'],
+            extra_cfg   = [],
             modulepath  = [ os.path.join(root, 'deps') ],
             modules     = instance['modules'])
     else:

--- a/makemehappy/cmake.py
+++ b/makemehappy/cmake.py
@@ -89,7 +89,7 @@ class InvalidZephyrModuleSpec(Exception):
 def configureZephyr(log, args, ufw,
                     board, buildtool, buildconfig, buildsystem,
                     toolchain, sourcedir, builddir, installdir,
-                    appsource, kernel, dtc, kconfig,
+                    appsource, kernel, dtc, kconfig, extra_cfg,
                     modulepath, modules):
     modules = z.generateModules(modulepath, modules)
 
@@ -117,6 +117,7 @@ def configureZephyr(log, args, ufw,
           makeParam('ZEPHYR_MODULES',         modules),
           makeParam('DTC_OVERLAY_FILE',       dtc),
           makeParam('OVERLAY_CONFIG',         overlay),
+          makeParam('EXTRA_CONF_FILE',        ':'.join(extra_cfg)),
           makeParam('UFW_ZEPHYR_KERNEL',      mmh.expandFile(kernel)),
           makeParam('UFW_ZEPHYR_APPLICATION', mmh.expandFile(appsource)),
           makeParam('UFW_LOAD_BUILD_SYSTEM',  mmh.expandFile(buildsystem)) ])

--- a/makemehappy/system.py
+++ b/makemehappy/system.py
@@ -211,6 +211,11 @@ class SystemInstanceZephyr:
         if (self.sys.args.cmake != None):
             cargs += self.sys.args.cmake
 
+        extra_cfg = []
+        if self.spec.get('config'):
+            if self.spec['config'].get(self.cfg):
+                extra_cfg.extend(self.spec['config'][self.cfg])
+
         cmd = c.configureZephyr(
             log         = self.sys.log,
             args        = cargs,
@@ -227,6 +232,7 @@ class SystemInstanceZephyr:
             kernel      = build['zephyr-kernel'],
             dtc         = build['dtc-overlays'],
             kconfig     = build['kconfig'],
+            extra_cfg   = extra_cfg,
             modulepath  = build['zephyr-module-path'],
             modules     = build['modules'])
 


### PR DESCRIPTION
The `config` key inside an instance allows the user to specify for any buildconfig which additional Kconfig overlays to load. This empowers the user to enable specific Kconfig options only for debug builds.