### PR TITLE
combinations: Fix output if part of combination build fails

### DIFF
--- a/makemehappy/combination.py
+++ b/makemehappy/combination.py
@@ -454,7 +454,7 @@ class Registry:
                     success = p.data.succeeded()
                     if not success:
                         self.log.warn(f'combination({name}):' +
-                                      ' {p.description} did not succeed')
+                                      f' {p.name} did not succeed')
                         self.log.warn(f'combination({name}): will be skipped')
                         parentsok = False
                 if not parentsok:


### PR DESCRIPTION
If a part of a combination build fails mmh tries to log the failed `ParentInstance`'s `description` field which doesn't exist. As the part of the concatonated string which tries to access the `description` member was not an f-string, python didn't evaluate it so it didn't throw an error.

Make the string an f-string and use the `name` field instead.